### PR TITLE
Allow for backlog of incoming TCP connections

### DIFF
--- a/engine/src/cython/initialize.cpp
+++ b/engine/src/cython/initialize.cpp
@@ -275,7 +275,7 @@ public:
       throw std::runtime_error("bind server");
     }
 
-    ret = listen(lsock_, 0);
+    ret = listen(lsock_, SOMAXCONN);
     if (ret < 0) {
       std::cout << "listen server" << std::endl;
       close(lsock_);


### PR DESCRIPTION
Fixes the problem where the UCX connection setup via sockets would fail. The reason was that there is a backlog of incoming connections piling up on the receiver side, and that the limit for the maximum number of backlogged connections was set to zero. Now it's set to the max  supported by the kernel (SOMAXCONN in `sys/socket.h`).

cf

https://man7.org/linux/man-pages/man2/listen.2.html